### PR TITLE
Fix slideindex attribute not updating carousel

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -32,14 +32,15 @@
     </style>
   </head>
   <body>
-    ​​<simple-carousel>
+    <simple-carousel>
       <div>
-        <h2>Heading</h2>
+        <h2>slideindex 0</h2>
         <p>Other stuff</p>
       </div>
-      <p>Second slide</p>
-      <div><h2>A third slide!</h2></div>
-      <div>4!!!</div>
+      <p>slideindex 1</p>
+      <div><h2>slideindex 2</h2></div>
+      <div>slideindex 3</div>
+      <div>slideindex 4</div>
     </simple-carousel>
   </body>
 </html>


### PR DESCRIPTION
### Context

In the video for simplicity we remove the ability for the carousel to be configurable by the attribute after the initial setup.

However a carousel should continue to support the `slideindex` attribute setting the slide.

### How

Originally `this.slideIndex` would schedule an update which would immediately set the carousel slide - and break the animation in the process. In the video we skip over this by removing the `updated` callback.

Now we split the internal slide index state and the attribute into a property and state. Changing the attribute calculates the nearest offset (left or right), and animates to that slide.

### Limitations

This is still a simplified model, as it's possible to race the animation & attribute update. However this is an improvement on the attribute being completely broken after initial render.

### Tested

Tested manually. In dev tools would manually set the slideindex attribute, i.e.: `<simple-carousel slideindex="3">`.

Tested incrementing positively and negatively, as well as randomly changing the index.

Tested with `npm run build && npm run serve`.